### PR TITLE
Add structured templates for GitHub discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ado-feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/ado-feature-requests.yml
@@ -1,0 +1,52 @@
+title: "[FEATURE REQUEST]: Brief description of the feature" # Users will complete the title
+labels: ["feature-request", "enhancement"] # Optional: add labels automatically
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please provide as much detail as possible.
+  - type: input
+    id: ado-name
+    attributes:
+      label: "1. Which existing ADO is this feature request for?"
+      description: "Specify the name of the ADO you'd like to see enhanced."
+      placeholder: "e.g., Marketplace ADO, NFT ADO, Crowdfund ADO"
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: "2. What is the current behavior (if applicable)?"
+      description: "A clear and concise description of what the ADO currently does in relation to your feature idea."
+      placeholder: "Currently, the ADO allows X, but not Y..."
+    validations:
+      required: false
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: "3. What is the desired behavior or new feature?"
+      description: "A clear and concise description of what you want to happen or be added."
+      placeholder: "I would like the ADO to also do Z, which would enable..."
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: "4. What is the use case or problem this feature solves?"
+      description: "How would this feature benefit users or developers? What problem does it address?"
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "5. Do you have a proposed solution or implementation ideas? (Optional)"
+      description: "If you have thoughts on how this could be implemented, please share."
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Add any other context, examples, or screenshots here."
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/ado-idea-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/ado-idea-proposals.yml
@@ -1,0 +1,53 @@
+title: "[ADO IDEA]: " # Users will complete the title
+labels: ["ado-idea", "proposal"] # Optional: add labels automatically
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose a new ADO! Please fill out the details below.
+  - type: textarea
+    id: problem-solved
+    attributes:
+      label: "1. What is the core problem your ADO solves?"
+      description: "A clear and concise description of the problem or need."
+      placeholder: "e.g., Users need a way to securely time-lock tokens for vesting schedules."
+    validations:
+      required: true
+  - type: textarea
+    id: ado-description
+    attributes:
+      label: "2. Describe your proposed ADO."
+      description: "What does it do? What are its key features and functionalities?"
+      placeholder: "e.g., A smart contract that allows users to deposit tokens which are then released incrementally to a beneficiary based on a predefined schedule..."
+    validations:
+      required: true
+  - type: input
+    id: target-user
+    attributes:
+      label: "3. Who is the target user for this ADO?"
+      description: "e.g., dApp developers, DAO treasuries, individual token holders"
+      placeholder: "Specify the primary users"
+    validations:
+      required: true
+  - type: textarea
+    id: benefits-impact
+    attributes:
+      label: "4. What are the potential benefits or impact of this ADO?"
+      description: "How would it improve the Andromeda ecosystem or user experience?"
+    validations:
+      required: true
+  - type: textarea
+    id: similar-concepts
+    attributes:
+      label: "5. Are there any similar existing ADOs or concepts (on Andromeda or other platforms)?"
+      description: "If so, how is your idea different or better?"
+      placeholder: "e.g., Similar to X, but offers Y improvement..."
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Add any other context, diagrams, mockups, or relevant links here."
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/ado-submissions.yml
+++ b/.github/DISCUSSION_TEMPLATE/ado-submissions.yml
@@ -1,0 +1,83 @@
+title: "[ADO SUBMISSION]: Name of Your ADO" # Users will complete the title
+labels: ["ado-submission", "evaluation"] # Optional
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting your ADO! Please provide the following details.
+  - type: input
+    id: ado-name
+    attributes:
+      label: "1. ADO Name"
+      description: "What is the official name of your ADO?"
+      placeholder: "e.g., Advanced Auction ADO"
+    validations:
+      required: true
+  - type: textarea
+    id: ado-summary
+    attributes:
+      label: "2. Summary / Abstract"
+      description: "Briefly describe what your ADO does and its primary purpose."
+    validations:
+      required: true
+  - type: input
+    id: repo-link
+    attributes:
+      label: "3. Link to Code Repository"
+      description: "Provide a public link to the source code (e.g., GitHub, GitLab)."
+      placeholder: "https://github.com/your-username/your-ado-repo"
+    validations:
+      required: true
+  - type: input
+    id: deployed-address
+    attributes:
+      label: "4. Deployed Contract Address(es) (Optional)"
+      description: "If deployed on a testnet or mainnet, provide the contract address(es)."
+      placeholder: "e.g., andr... (testnet), osmo... (mainnet)"
+    validations:
+      required: false
+  - type: textarea
+    id: documentation-link
+    attributes:
+      label: "5. Link to Documentation (Highly Recommended)"
+      description: "Provide a link to user guides, API references, or other documentation."
+      placeholder: "e.g., Link to your GitBook, README, etc."
+    validations:
+      required: false
+  - type: textarea
+    id: key-features
+    attributes:
+      label: "6. Key Features & Functionality"
+      description: "List the main features and what users can do with your ADO."
+    validations:
+      required: true
+  - type: dropdown
+    id: testing-status
+    attributes:
+      label: "7. Testing Status"
+      description: "What is the current testing status of your ADO?"
+      options:
+        - "Fully unit tested"
+        - "Partially unit tested"
+        - "Integration tests written"
+        - "Deployed and tested on testnet"
+        - "Audited (please provide audit report link if possible)"
+        - "Not yet extensively tested"
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: license
+    attributes:
+      label: "8. License"
+      description: "What software license is your ADO released under?"
+      placeholder: "e.g., Apache 2.0, MIT, GPLv3"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: "9. Additional Information or Comments"
+      description: "Anything else you'd like to share about your submission?"
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/general-feedback.yml
+++ b/.github/DISCUSSION_TEMPLATE/general-feedback.yml
@@ -1,0 +1,28 @@
+title: "[FEEDBACK/QUESTION]: " # Users will complete the title
+labels: ["feedback", "question"] # Optional
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We appreciate your feedback and questions! Please provide details below.
+  - type: textarea
+    id: feedback-details
+    attributes:
+      label: "Your Feedback, Question, or Discussion Topic"
+      description: "Please be as specific as possible. If reporting an issue, include steps to reproduce if applicable."
+      placeholder: "Enter your feedback, question, or topic here..."
+    validations:
+      required: true
+  - type: dropdown
+    id: topic-type
+    attributes:
+      label: "Type of Topic (Optional)"
+      description: "Help us categorize your post."
+      options:
+        - "General Feedback"
+        - "Question about Andromeda"
+        - "Documentation Issue"
+        - "Community Suggestion"
+        - "Other"
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,41 @@
+title: "[SHOW & TELL]: My Project - " # Users will complete the title
+labels: ["show-and-tell", "community-project"] # Optional
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Awesome! We'd love to see what you've built. Please share some details.
+  - type: input
+    id: project-name
+    attributes:
+      label: "1. Project Name"
+      description: "What is the name of your project?"
+    validations:
+      required: true
+  - type: textarea
+    id: project-description
+    attributes:
+      label: "2. Project Description"
+      description: "Tell us about your project. What does it do? What ADOs or Andromeda features does it use?"
+      placeholder: "Describe your project here..."
+    validations:
+      required: true
+  - type: input
+    id: project-link
+    attributes:
+      label: "3. Link to Project (e.g., Live Demo, GitHub Repo, Video)"
+      description: "Where can we see or learn more about your project?"
+      placeholder: "https://..."
+    validations:
+      required: true
+  - type: textarea
+    id: challenges-learnings
+    attributes:
+      label: "4. Challenges or Key Learnings (Optional)"
+      description: "Did you face any interesting challenges or have any key takeaways while building this?"
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Feel free to include screenshots or short videos if they help showcase your project!


### PR DESCRIPTION
Create templates for different discussion categories:
- ADO feature requests
- ADO idea proposals
- ADO submissions
- General feedback and questions
- Show and tell projects